### PR TITLE
upgrading from raven to sentry sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ python app.py
 This app uses [Redis](https://redis.io/), a data store that brokers messages between a sender and receiver. You need to [download Redis](https://redis.io/download), first. Then, you can put Redis to "work." In a new terminal tab, run:
 
 ```bash
+redis-server
+```
+
+And in another tab, run:
+
+```bash
 python run_worker.py
 ```
 
@@ -103,10 +109,10 @@ python manage.py compile_pdfs
 
 ## AWS Buckets
 
-We store the merged PDF packets in an AWS S3 bucket. You may want to test this tool locally, but still send PDFs to AWS. To so, you need to have the right credentials, and you need to tell your app to send PDFs to our test S3 bucket. 
+We store the merged PDF packets in an AWS S3 bucket. You may want to test this tool locally, but still send PDFs to AWS. To so, you need to have the right credentials, and you need to tell your app to send PDFs to our test S3 bucket.
 
 * Go to [https://console.aws.amazon.com/iam/](https://console.aws.amazon.com/iam/), and select your user name.
-* Select "Create Access Key," and download the relevant `.csv` file. 
+* Select "Create Access Key," and download the relevant `.csv` file.
 * At the root of your local machine (e.g., `~`), add an AWS directory and create two files:
 
 ```
@@ -136,7 +142,7 @@ Finally, tell the app where to save merged PDFs. Add the following to `config.py
 S3_BUCKET = 'datamade-metro-pdf-merger-testing'
 ```
 
-Head over to the AWS console, and watch Metro PDF packets appear! 
+Head over to the AWS console, and watch Metro PDF packets appear!
 
 ## Team
 
@@ -158,7 +164,3 @@ Report it here: https://github.com/datamade/nyc-councilmatic/issues
 ## Copyright
 
 Copyright (c) 2017 DataMade. Released under the [MIT License](https://github.com/datamade/nyc-councilmatic/blob/master/LICENSE).
-
-
-
-

--- a/app.py
+++ b/app.py
@@ -3,7 +3,10 @@ from flask_cors import cross_origin
 
 import json
 from redis import Redis
-from raven.contrib.flask import Sentry
+
+import sentry_sdk
+from sentry_sdk.integrations.flask import FlaskIntegration
+
 import boto3
 import botocore
 
@@ -14,7 +17,11 @@ app = Flask(__name__)
 app.config.from_object('config')
 
 redis = Redis()
-sentry = Sentry(app, dsn=SENTRY_DSN)
+
+sentry_sdk.init(
+    dsn=SENTRY_DSN,
+    integrations=[FlaskIntegration()]
+)
 
 
 @app.route('/')

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ Flask-Cors==3.0.2
 PyPDF2==1.26.0
 requests==2.13.0
 redis==2.10.5
-raven[flask]
+sentry-sdk[flask]==0.10.2
 gunicorn==19.7.1
 boto3==1.4.7

--- a/tasks.py
+++ b/tasks.py
@@ -15,7 +15,7 @@ from redis import Redis
 
 from PyPDF2 import PdfFileMerger, PdfFileReader
 
-from raven import Client
+from sentry_sdk import capture_exception
 
 from subprocess import check_output, CalledProcessError
 
@@ -27,7 +27,6 @@ redis = Redis()
 
 logging.config.dictConfig(LOGGING)
 logger = logging.getLogger(__name__)
-client = Client(SENTRY_DSN)
 
 
 class DelayedResult(object):
@@ -119,7 +118,7 @@ def makePacket(merged_id, filenames_collection):
         logger.info(("Successful merge! {}").format(merged_id))
     except:
         logger.error(("{0} caused the failure of writing {1} as a PDF, and we could not merge this file collection: \n {2}").format(sys.exc_info()[0], merged_id, filenames_collection))
-        client.captureException()
+        capture_exception()
 
     return merger
 
@@ -189,4 +188,4 @@ def error_logging(attempts, filename):
         logger.info('Trying again...')
     else:
         logger.error(("Something went wrong. Please look at {}. \n").format(filename))
-        client.captureException()
+        capture_exception()

--- a/tasks.py
+++ b/tasks.py
@@ -21,7 +21,7 @@ from subprocess import check_output, CalledProcessError
 
 import boto3
 
-from config import REDIS_QUEUE_KEY, LOGGING, SENTRY_DSN, S3_BUCKET
+from config import REDIS_QUEUE_KEY, LOGGING, S3_BUCKET
 
 redis = Redis()
 


### PR DESCRIPTION
This PR replaces the deprecated `raven` package with the new [`sentry-sdk`](https://docs.sentry.io/error-reporting/quickstart/?platform=python).

- Switched out package in requirements
- Initialized in `app.py`
- Changed syntax for catching exceptions in `tasks.py`

How to test:
- Add the Sentry DSN to your local config file. 
- Add the following in `app.py`:
```python
@app.route('/test/)
def fail():
     return 1 / 0  # or something else that will trigger an error
```
- Run the server 
- Navigate to the route you just created.
- Log on to sentry.io and look at the errors for `metr-pdf-merger`. 
- Confirm there is a ZeroDivisionError (or corresponding error) logged.
